### PR TITLE
fix(caching): re-etablish caching for feature-flag compoment fetching

### DIFF
--- a/src/app/feature-loader/feature-loader.component.spec.ts
+++ b/src/app/feature-loader/feature-loader.component.spec.ts
@@ -50,7 +50,7 @@ describe('FeatureContainerComponent', () => {
 
 
   beforeEach(() => {
-    featureServiceMock = jasmine.createSpyObj('FeatureTogglesService', ['getFeatures']);
+    featureServiceMock = jasmine.createSpyObj('FeatureTogglesService', ['getFeature']);
     featureFlagMappingMock = jasmine.createSpyObj('FeatureFlagMapping', ['convertFeatureNameToComponent']);
 
     TestBed.configureTestingModule({
@@ -73,7 +73,7 @@ describe('FeatureContainerComponent', () => {
 
   it('should render content if toggles is on and user-enabled on', async(() => {
     // given
-    featureServiceMock.getFeatures.and.returnValue(Observable.of([feature]));
+    featureServiceMock.getFeature.and.returnValue(Observable.of(feature));
     featureFlagMappingMock.convertFeatureNameToComponent.and.returnValue(MyFeatureCompomentUnderDevComponent);
     hostFixture.detectChanges();
     hostFixture.whenStable().then(() => {
@@ -85,7 +85,7 @@ describe('FeatureContainerComponent', () => {
     // given
     feature.attributes.enabled = false;
     feature.attributes['user-enabled'] = true;
-    featureServiceMock.getFeatures.and.returnValue(Observable.of([feature]));
+    featureServiceMock.getFeature.and.returnValue(Observable.of(feature));
     featureFlagMappingMock.convertFeatureNameToComponent.and.returnValue(MyFeatureCompomentUnderDevComponent);
     hostFixture.detectChanges();
     hostFixture.whenStable().then(() => {
@@ -97,7 +97,7 @@ describe('FeatureContainerComponent', () => {
     // given
     feature.attributes.enabled = true;
     feature.attributes['user-enabled'] = false;
-    featureServiceMock.getFeatures.and.returnValue(Observable.of([feature]));
+    featureServiceMock.getFeature.and.returnValue(Observable.of(feature));
     featureFlagMappingMock.convertFeatureNameToComponent.and.returnValue(MyFeatureCompomentUnderDevComponent);
     hostFixture.detectChanges();
     hostFixture.whenStable().then(() => {
@@ -109,7 +109,7 @@ describe('FeatureContainerComponent', () => {
     // given
     feature.attributes.enabled = false;
     feature.attributes['user-enabled'] = false;
-    featureServiceMock.getFeatures.and.returnValue(Observable.of([feature]));
+    featureServiceMock.getFeature.and.returnValue(Observable.of(feature));
     featureFlagMappingMock.convertFeatureNameToComponent.and.returnValue(MyFeatureCompomentUnderDevComponent);
     hostFixture.detectChanges();
     hostFixture.whenStable().then(() => {

--- a/src/app/feature-loader/feature-loader.component.ts
+++ b/src/app/feature-loader/feature-loader.component.ts
@@ -13,11 +13,11 @@ export class FeatureContainerComponent implements OnInit {
   constructor(private featureService: FeatureTogglesService, private featureFlagMapping: FeatureFlagMapping) {}
 
   ngOnInit() {
-    this.featureService.getFeatures([this.featureName]).subscribe(feats => {
-      if (feats && feats.length > 0) {
-        if (this.featureName === feats[0].id) {
-          if (feats[0].attributes.enabled && feats[0].attributes['user-enabled']) {
-            this.featureComponent = this.featureFlagMapping.convertFeatureNameToComponent(feats[0].id);
+    this.featureService.getFeature(this.featureName).subscribe(feat => {
+      if (feat) {
+        if (this.featureName === feat.id) {
+          if (feat.attributes.enabled && feat.attributes['user-enabled']) {
+            this.featureComponent = this.featureFlagMapping.convertFeatureNameToComponent(feat.id);
           } else {
             this.featureComponent = null;
           }

--- a/src/app/feature-wrapper/feature-toggle.component.spec.ts
+++ b/src/app/feature-wrapper/feature-toggle.component.spec.ts
@@ -30,7 +30,7 @@ describe('FeatureToggleComponent', () => {
   class TestHostComponent {
   }
   beforeEach(() => {
-    featureServiceMock = jasmine.createSpyObj('FeatureTogglesService', ['getFeatures']);
+    featureServiceMock = jasmine.createSpyObj('FeatureTogglesService', ['getFeature']);
 
     TestBed.configureTestingModule({
       imports: [FormsModule, HttpModule],
@@ -48,7 +48,7 @@ describe('FeatureToggleComponent', () => {
 
   it('should render content if toggles is on and user-enabled on', async(() => {
     // given
-    featureServiceMock.getFeatures.and.returnValue(Observable.of([feature]));
+    featureServiceMock.getFeature.and.returnValue(Observable.of(feature));
     hostFixture.detectChanges();
     hostFixture.whenStable().then(() => {
       expect(hostFixture.nativeElement.querySelector('div').innerText).toEqual('My content here');
@@ -59,7 +59,7 @@ describe('FeatureToggleComponent', () => {
     // given
     feature.attributes.enabled = false;
     feature.attributes['user-enabled'] = true;
-    featureServiceMock.getFeatures.and.returnValue(Observable.of([feature]));
+    featureServiceMock.getFeature.and.returnValue(Observable.of(feature));
     hostFixture.detectChanges();
     hostFixture.whenStable().then(() => {
       expect(hostFixture.nativeElement.querySelector('div')).toBeNull();
@@ -70,7 +70,7 @@ describe('FeatureToggleComponent', () => {
     // given
     feature.attributes.enabled = true;
     feature.attributes['user-enabled'] = false;
-    featureServiceMock.getFeatures.and.returnValue(Observable.of([feature]));
+    featureServiceMock.getFeature.and.returnValue(Observable.of(feature));
     hostFixture.detectChanges();
     hostFixture.whenStable().then(() => {
       expect(hostFixture.nativeElement.querySelector('div')).toBeNull();
@@ -81,7 +81,7 @@ describe('FeatureToggleComponent', () => {
     // given
     feature.attributes.enabled = false;
     feature.attributes['user-enabled'] = false;
-    featureServiceMock.getFeatures.and.returnValue(Observable.of([feature]));
+    featureServiceMock.getFeature.and.returnValue(Observable.of(feature));
     hostFixture.detectChanges();
     hostFixture.whenStable().then(() => {
       expect(hostFixture.nativeElement.querySelector('div')).toBeNull();

--- a/src/app/feature-wrapper/feature-toggle.component.ts
+++ b/src/app/feature-wrapper/feature-toggle.component.ts
@@ -20,9 +20,9 @@ export class FeatureToggleComponent implements OnInit {
     if (!this.featureName) {
       throw new Error('Attribute `featureName` should not be null or empty');
     }
-    this.featureService.getFeatures([this.featureName]).subscribe((f: Feature[]) => {
-       if (f && f.length > 0) {
-         this.isEnabled = f[0].attributes.enabled && f[0].attributes['user-enabled'];
+    this.featureService.getFeature(this.featureName).subscribe((feature: Feature) => {
+       if (feature) {
+         this.isEnabled = feature.attributes.enabled && feature.attributes['user-enabled'];
        }
     },
     err => {

--- a/src/app/service/feature-toggles.service.ts
+++ b/src/app/service/feature-toggles.service.ts
@@ -37,7 +37,6 @@ export class FeatureTogglesService {
   /**
    * Check if a given feature id is user-enabled for a given user (the user identity being carried with auth token).
    * It also return if the feature is enabled for any users.
-   * @deprecated
    * @returns {Observable<Feature>}
    */
   getFeature(id: string): Observable<Feature> {

--- a/src/demo/service/feature-toggles-mock.service.ts
+++ b/src/demo/service/feature-toggles-mock.service.ts
@@ -33,7 +33,7 @@ export class FeatureTogglesServiceMock  {
     }
     return false;
   }
-  getFeatures(ids: string[]): Observable<Feature[]> {
+  getFeature(id: string): Observable<Feature> {
     const feature =  {
       attributes: {
         'user-enabled': this.isUserLevelEnabled(),
@@ -44,10 +44,10 @@ export class FeatureTogglesServiceMock  {
       },
       id: this.featureFlagName
     } as Feature;
-    let mock = [feature];
-    if (ids[0] === this.featureFlagName) {
-      return Observable.of(mock);
+
+    if (id === this.featureFlagName) {
+      return Observable.of(feature);
     }
-    return Observable.of([]);
+    return Observable.of();
   }
 }


### PR DESCRIPTION
`getFeature` method should not be deprecated, this is the method to used within wraper and loader component to use cached value (reducing to one call per page instead of n-component calls).