### PR TITLE
Add feature service api

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@angular/platform-browser-dynamic": "4.4.6",
     "@angular/router": "4.4.6",
     "@krux/condition-jenkins": "1.0.1",
-    "@types/jasmine": "2.5.47",
+    "@types/jasmine": "2.6.2",
     "@ngtools/webpack": "1.8.4",
     "angular2-template-loader": "0.6.2",
     "awesome-typescript-loader": "3.1.2",

--- a/src/app/feature-wrapper/feature-toggle.component.spec.ts
+++ b/src/app/feature-wrapper/feature-toggle.component.spec.ts
@@ -1,27 +1,14 @@
-import { Component, NO_ERRORS_SCHEMA } from '@angular/core';
+import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 import { Observable } from 'rxjs';
 import { FeatureTogglesService } from '../service/feature-toggles.service';
 import { FeatureToggleComponent } from './feature-toggle.component';
-import { Feature } from '../models/feature';
 
 describe('FeatureToggleComponent', () => {
-  let featureServiceMock: any;
-  let hostComponent: TestHostComponent;
+  let featureServiceMock: jasmine.SpyObj<FeatureTogglesService>;
   let hostFixture: ComponentFixture<TestHostComponent>;
-
-  let feature: Feature = {
-    attributes: {
-      name: 'Planner',
-      description: 'Description',
-      enabled: true,
-      'enablement-level': 'beta',
-      'user-enabled': true
-    },
-    id: 'Planner'
-  };
 
   @Component({
     selector: `host-component`,
@@ -30,7 +17,7 @@ describe('FeatureToggleComponent', () => {
   class TestHostComponent {
   }
   beforeEach(() => {
-    featureServiceMock = jasmine.createSpyObj('FeatureTogglesService', ['getFeature']);
+    featureServiceMock = jasmine.createSpyObj('FeatureTogglesService', ['isFeatureUserEnabled']);
 
     TestBed.configureTestingModule({
       imports: [FormsModule, HttpModule],
@@ -43,45 +30,20 @@ describe('FeatureToggleComponent', () => {
     });
 
     hostFixture = TestBed.createComponent(TestHostComponent);
-    hostComponent = hostFixture.componentInstance;
   });
 
-  it('should render content if toggles is on and user-enabled on', async(() => {
+  it('should render content if feature is user enabled', async(() => {
     // given
-    featureServiceMock.getFeature.and.returnValue(Observable.of(feature));
+    featureServiceMock.isFeatureUserEnabled.and.returnValue(Observable.of(true));
     hostFixture.detectChanges();
     hostFixture.whenStable().then(() => {
       expect(hostFixture.nativeElement.querySelector('div').innerText).toEqual('My content here');
     });
   }));
 
-  it('should not render content if toggles is off and user-enabled on', async(() => {
+  it('should not render content if feature is not user enabled', async(() => {
     // given
-    feature.attributes.enabled = false;
-    feature.attributes['user-enabled'] = true;
-    featureServiceMock.getFeature.and.returnValue(Observable.of(feature));
-    hostFixture.detectChanges();
-    hostFixture.whenStable().then(() => {
-      expect(hostFixture.nativeElement.querySelector('div')).toBeNull();
-    });
-  }));
-
-  it('should not render content if toggles is on and user-enabled off', async(() => {
-    // given
-    feature.attributes.enabled = true;
-    feature.attributes['user-enabled'] = false;
-    featureServiceMock.getFeature.and.returnValue(Observable.of(feature));
-    hostFixture.detectChanges();
-    hostFixture.whenStable().then(() => {
-      expect(hostFixture.nativeElement.querySelector('div')).toBeNull();
-    });
-  }));
-
-  it('should not render content if toggles is off and user-enabled off', async(() => {
-    // given
-    feature.attributes.enabled = false;
-    feature.attributes['user-enabled'] = false;
-    featureServiceMock.getFeature.and.returnValue(Observable.of(feature));
+    featureServiceMock.isFeatureUserEnabled.and.returnValue(Observable.of(false));
     hostFixture.detectChanges();
     hostFixture.whenStable().then(() => {
       expect(hostFixture.nativeElement.querySelector('div')).toBeNull();

--- a/src/app/feature-wrapper/feature-toggle.component.ts
+++ b/src/app/feature-wrapper/feature-toggle.component.ts
@@ -4,7 +4,6 @@ import {
   OnInit
 } from '@angular/core';
 import { FeatureTogglesService } from '../service/feature-toggles.service';
-import { Feature } from '../models/feature';
 
 @Component({
   selector: 'f8-feature-toggle',
@@ -20,14 +19,9 @@ export class FeatureToggleComponent implements OnInit {
     if (!this.featureName) {
       throw new Error('Attribute `featureName` should not be null or empty');
     }
-    this.featureService.getFeature(this.featureName).subscribe((feature: Feature) => {
-       if (feature) {
-         this.isEnabled = feature.attributes.enabled && feature.attributes['user-enabled'];
-       }
-    },
-    err => {
-      this.isEnabled = false;
-      console.log('This feature is not accessible in fabric8-toggles-service' + err);
+
+    this.featureService.isFeatureUserEnabled(this.featureName).subscribe((isEnabled: boolean) => {
+      this.isEnabled = isEnabled;
     });
   }
 

--- a/src/app/service/feature-toggles.service.ts
+++ b/src/app/service/feature-toggles.service.ts
@@ -34,6 +34,18 @@ export class FeatureTogglesService {
     this._featureFlagCache = new Map<string, Feature[]>();
   }
 
+  isFeatureUserEnabled(id: string): Observable<boolean> {
+    return this.getFeature(id)
+      .map((feature: Feature) => {
+        if (feature.attributes) {
+          return feature.attributes.enabled && feature.attributes['user-enabled'];
+        } else {
+          return false;
+        }
+      })
+      .catch(() => Observable.of(false));
+  }
+
   /**
    * Check if a given feature id is user-enabled for a given user (the user identity being carried with auth token).
    * It also return if the feature is enabled for any users.


### PR DESCRIPTION
This moves some of the logic from the feature toggles component into the service, adding an API to check for the feature level and return a boolean for displaying user or default level. Surrounding code is cleaned up as well.

The first commit updates the type definitions for jasmine to a version matching the dependency in fabric8-ui. The type definitions in this version are also much improved.