### PR TITLE
feat(resolver): move feature-flag.resolver from fabric8-ui to ngx-feature-flag

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,7 @@ export { FeatureTogglesService, FABRIC8_FEATURE_TOGGLES_API_URL } from './src/ap
 
 export { Feature } from './src/app/models/feature';
 export { FeatureFlagConfig } from './src/app/models/feature-flag-config';
+export { FeatureFlagResolver } from './src/app/resolver/feature-flag.resolver';
 
 export { FeatureFlagModule } from './src/app/feature-flag.module';
 

--- a/src/app/feature-flag.module.ts
+++ b/src/app/feature-flag.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { FeatureFlagMapping } from './feature-flag.mapping';
+import { FeatureFlagResolver } from './resolver/feature-flag.resolver';
 import { FeatureContainerComponent } from './feature-loader/feature-loader.component';
 import { FeatureToggleComponent } from './feature-wrapper/feature-toggle.component';
 import { FeatureFlagHomeComponent } from './home/feature-flag-home.component';
@@ -21,7 +22,7 @@ import { FeatureWarningPageComponent } from './warning-page/feature-warning-page
     FeatureWarningPageComponent,
     FeatureFlagHomeComponent
   ],
-  providers: [FeatureFlagMapping]
+  providers: [FeatureFlagMapping, FeatureFlagResolver]
 
 })
 export class FeatureFlagModule { }

--- a/src/app/feature-flag.module.ts
+++ b/src/app/feature-flag.module.ts
@@ -2,7 +2,6 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { FeatureFlagMapping } from './feature-flag.mapping';
-import { FeatureFlagResolver } from './resolver/feature-flag.resolver';
 import { FeatureContainerComponent } from './feature-loader/feature-loader.component';
 import { FeatureToggleComponent } from './feature-wrapper/feature-toggle.component';
 import { FeatureFlagHomeComponent } from './home/feature-flag-home.component';
@@ -22,7 +21,7 @@ import { FeatureWarningPageComponent } from './warning-page/feature-warning-page
     FeatureWarningPageComponent,
     FeatureFlagHomeComponent
   ],
-  providers: [FeatureFlagMapping, FeatureFlagResolver]
+  providers: [FeatureFlagMapping]
 
 })
 export class FeatureFlagModule { }

--- a/src/app/resolver/feature-flag.resolver.spec.ts
+++ b/src/app/resolver/feature-flag.resolver.spec.ts
@@ -1,0 +1,137 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+
+import { Logger } from 'ngx-base';
+import { UserService } from 'ngx-login-client';
+import { Observable } from 'rxjs';
+import { FeatureFlagResolver } from './feature-flag.resolver';
+
+import { Feature } from '../models/feature';
+import { FeatureFlagConfig } from '../models/feature-flag-config';
+import { FeatureTogglesService } from '../service/feature-toggles.service';
+
+
+describe('FeatureFlag resolver: it', () => {
+  let mockLog: any;
+  let mockRouter: any;
+  let mockTogglesService: any;
+  let mockUserService: any;
+  let resolver: FeatureFlagResolver;
+  let mockActivatedRoute: any;
+  beforeEach(() => {
+    mockLog = jasmine.createSpyObj('Logger', ['log']);
+    mockTogglesService = jasmine.createSpyObj('FeatureTogglesService', ['getFeaturesPerPage']);
+    mockUserService = jasmine.createSpy('UserService');
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockActivatedRoute = jasmine.createSpy('ActivatedRouteSnapshot');
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: Logger,
+          useValue: mockLog
+        },
+        {
+          provide: Router,
+          useValue: mockRouter
+        },
+        {
+          provide: UserService,
+          useValue: mockUserService
+        },
+        {
+          provide: FeatureTogglesService,
+          useValue: mockTogglesService
+        },
+        FeatureFlagResolver
+      ]
+    });
+    resolver = TestBed.get(FeatureFlagResolver);
+  });
+
+  it('should route to requested feature', () => {
+    // given
+    let route = new ActivatedRouteSnapshot();
+    route.data = {featureName: 'Deployment'};
+    mockUserService.currentLoggedInUser = {
+      attributes: {
+        featureLevel: 'internal'
+      }
+    };
+    let feature = {id: 'Deployment', attributes: {
+      enabled: true,
+      'user-enabled': true,
+      'enablement-level': 'internal'
+    }} as Feature;
+    const expected = {
+      'user-level': 'internal',
+      featuresPerLevel: {
+        internal: [{
+          id: 'Deployment',
+          attributes: {
+            enabled: true,
+            'user-enabled': true,
+            'enablement-level': 'internal'
+          }
+        }],
+        experimental: [],
+        beta: []
+      }
+    } as FeatureFlagConfig;
+    mockTogglesService.getFeaturesPerPage.and.returnValue(Observable.of([feature]));
+    // when
+    resolver.resolve(route as ActivatedRouteSnapshot, null).subscribe(val => {
+      // then
+      expect(val.featuresPerLevel.internal.length).toEqual(1);
+      expect(val.featuresPerLevel.internal[0].id).toEqual(expected.featuresPerLevel.internal[0].id);
+      expect(val['user-level']).toEqual(expected['user-level']);
+    });
+  });
+
+  it('should route to error when requested feature is not-enabled', () => {
+    // given
+    let route = new ActivatedRouteSnapshot();
+    route.data = {featureName: 'Deployment'};
+    mockUserService.currentLoggedInUser = {
+      attributes: {
+        featureLevel: 'internal'
+      }
+    };
+    let feature = {id: 'Deployment', attributes: {
+      enabled: false,
+      'user-enabled': true,
+      'enablement-level': 'internal'
+    }} as Feature;
+    mockTogglesService.getFeaturesPerPage.and.returnValue(Observable.of([feature]));
+    // when
+    resolver.resolve(route, null).subscribe(val => {
+      // then
+      expect(val).toBeNull();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/_error']);
+    });
+  });
+
+  it('should route to opt-in when requested feature is not-user-enabled', () => {
+    // given
+    let route = new ActivatedRouteSnapshot();
+    route.data = {featureName: 'Deployment'};
+    mockUserService.currentLoggedInUser = {
+      attributes: {
+        featureLevel: 'beta'
+      }
+    };
+    let feature = {id: 'Deployment', attributes: {
+      enabled: true,
+      'user-enabled': false,
+       'enablement-level': 'internal'
+    }} as Feature;
+    mockTogglesService.getFeaturesPerPage.and.returnValue(Observable.of([feature]));
+    // when
+    resolver.resolve(route, null).subscribe(val => {
+      // then
+      expect(val).toBeNull();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/_featureflag'], {queryParams: {
+          showBanner: 'internal'
+        }});
+    });
+  });
+});

--- a/src/app/resolver/feature-flag.resolver.ts
+++ b/src/app/resolver/feature-flag.resolver.ts
@@ -1,0 +1,147 @@
+import { Injectable } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  Resolve,
+  Router,
+  RouterStateSnapshot
+} from '@angular/router';
+import { Logger } from 'ngx-base';
+import { UserService } from 'ngx-login-client';
+import { Observable } from 'rxjs';
+
+import { Feature } from '../models/feature';
+import { FeatureFlagConfig } from '../models/feature-flag-config';
+import { FeatureTogglesService } from '../service/feature-toggles.service';
+
+
+enum FeatureLevel {
+  internal = 'internal',
+  released = 'released',
+  notApplicable = 'notApplicable', // non redhat user trying to access internal feature
+  systemError = 'systemError', // f8-toggles-service is down, this features is disabled by PM for all level
+  experimental = 'experimental',
+  beta = 'beta'
+}
+@Injectable()
+export class FeatureFlagResolver implements Resolve<FeatureFlagConfig> {
+  userLevel: string = 'released';
+  constructor(private logger: Logger,
+              private toggleService: FeatureTogglesService,
+              private router: Router,
+              private userService: UserService) {
+    if (this.userService.currentLoggedInUser && this.userService.currentLoggedInUser.attributes) {
+      this.userLevel = (this.userService.currentLoggedInUser.attributes as any).featureLevel;
+    }
+  }
+   buildFeaturePerLevelView(features: Feature[], userLevel: string): FeatureFlagConfig {
+     let internal: Feature[] = [];
+     let experimental: Feature[] = [];
+     let beta: Feature[] = [];
+     let mainFeature: Feature;
+     for (let feature of features) {
+       if (feature.id.indexOf('.') === -1) {
+         mainFeature = feature;
+       }
+       feature.attributes.name = feature.id.replace('.', ' ');
+       switch (feature.attributes['enablement-level']) {
+         case 'beta': {
+           if (feature.attributes['enabled'] && feature.attributes['user-enabled']) {
+             beta.push(feature);
+           }
+           break;
+         }
+         case 'experimental': {
+           if (feature.attributes['enabled'] && feature.attributes['user-enabled']) {
+             experimental.push(feature);
+           }
+           break;
+         }
+         case 'internal': {
+           if (feature.attributes['enabled'] && feature.attributes['user-enabled']) {
+             internal.push(feature);
+           }
+           break;
+         }
+         default: {
+           break;
+         }
+       }
+     }
+     // this.logger.log('>> Feature = ' + featureName + ' enabled = ' + mainFeature.attributes['enabled']);
+     // if no feature at page menu level, the page has only component featuresmergeMa
+     if (!mainFeature) {
+       return {
+         'user-level': this.userLevel,
+         featuresPerLevel: {
+           internal,
+           experimental,
+           beta
+         }
+       } as FeatureFlagConfig;
+     } else if (!mainFeature.attributes['enabled']) { // PM has disabled the feature for all users
+       return null;
+     } else {
+       let enablementLevel = this.getBannerColor(mainFeature.attributes['enablement-level']);
+       if (enablementLevel === 'notApplicable') {
+         // for non-internal user trying to see internal feature toggles-service return a enablement-level null
+         // route to error page.
+         return null;
+       } else if (mainFeature.attributes['user-enabled']) { // feature is not toggled off and user-level is enabled
+         return {
+           'user-level': this.userLevel,
+           featuresPerLevel: {
+             internal,
+             experimental,
+             beta
+           }
+         } as FeatureFlagConfig;
+       } else { // feature is not toggled off but user-level is disabled, forward to opt-in page
+         return {
+           showBanner: this.getBannerColor(mainFeature.attributes['enablement-level'])
+         };
+       }
+     }
+   }
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<FeatureFlagConfig> {
+    let featureName = route.data['featureName']; // + '.*';
+    if (this.userService.currentLoggedInUser && this.userService.currentLoggedInUser.attributes) {
+      this.userLevel = (this.userService.currentLoggedInUser.attributes as any).featureLevel;
+    }
+    return this.toggleService.getFeaturesPerPage(featureName).map((features: Feature[]) => {
+       let config = this.buildFeaturePerLevelView(features, this.userLevel);
+       if (config == null) {
+         this.router.navigate(['/_error']);
+       } else if (!config.featuresPerLevel) {
+         this.router.navigate(['/_featureflag'], {queryParams: {
+             showBanner: config.showBanner
+           } });
+         return null;
+       }
+       return config;
+    }).catch (err => {
+        return Observable.of({
+          showBanner: FeatureLevel.systemError
+        } as FeatureFlagConfig);
+      });
+  }
+
+  private getBannerColor(level: string): string {
+    if (!level) {
+      return FeatureLevel.notApplicable as string;
+    }
+    if (level.toLocaleLowerCase() === 'beta') {
+      return FeatureLevel.beta as string;
+    }
+    if (level.toLocaleLowerCase() === 'released') {
+      return FeatureLevel.released as string;
+    }
+    if (level.toLocaleLowerCase() === 'internal') {
+      return FeatureLevel.internal as string;
+    }
+    if (level.toLocaleLowerCase() === 'experimental') {
+      return FeatureLevel.experimental as string;
+    }
+    return FeatureLevel.notApplicable as string;
+  }
+
+}

--- a/src/app/resolver/feature-flag.resolver.ts
+++ b/src/app/resolver/feature-flag.resolver.ts
@@ -25,100 +25,104 @@ enum FeatureLevel {
 @Injectable()
 export class FeatureFlagResolver implements Resolve<FeatureFlagConfig> {
   userLevel: string = 'released';
-  constructor(private logger: Logger,
-              private toggleService: FeatureTogglesService,
-              private router: Router,
-              private userService: UserService) {
+
+  constructor(
+    private toggleService: FeatureTogglesService,
+    private router: Router,
+    private userService: UserService
+  ) {
     if (this.userService.currentLoggedInUser && this.userService.currentLoggedInUser.attributes) {
       this.userLevel = (this.userService.currentLoggedInUser.attributes as any).featureLevel;
     }
   }
-   buildFeaturePerLevelView(features: Feature[], userLevel: string): FeatureFlagConfig {
-     let internal: Feature[] = [];
-     let experimental: Feature[] = [];
-     let beta: Feature[] = [];
-     let mainFeature: Feature;
-     for (let feature of features) {
-       if (feature.id.indexOf('.') === -1) {
-         mainFeature = feature;
-       }
-       feature.attributes.name = feature.id.replace('.', ' ');
-       switch (feature.attributes['enablement-level']) {
-         case 'beta': {
-           if (feature.attributes['enabled'] && feature.attributes['user-enabled']) {
-             beta.push(feature);
-           }
-           break;
-         }
-         case 'experimental': {
-           if (feature.attributes['enabled'] && feature.attributes['user-enabled']) {
-             experimental.push(feature);
-           }
-           break;
-         }
-         case 'internal': {
-           if (feature.attributes['enabled'] && feature.attributes['user-enabled']) {
-             internal.push(feature);
-           }
-           break;
-         }
-         default: {
-           break;
-         }
-       }
-     }
-     // this.logger.log('>> Feature = ' + featureName + ' enabled = ' + mainFeature.attributes['enabled']);
-     // if no feature at page menu level, the page has only component featuresmergeMa
-     if (!mainFeature) {
-       return {
-         'user-level': this.userLevel,
-         featuresPerLevel: {
-           internal,
-           experimental,
-           beta
-         }
-       } as FeatureFlagConfig;
-     } else if (!mainFeature.attributes['enabled']) { // PM has disabled the feature for all users
-       return null;
-     } else {
-       let enablementLevel = this.getBannerColor(mainFeature.attributes['enablement-level']);
-       if (enablementLevel === 'notApplicable') {
-         // for non-internal user trying to see internal feature toggles-service return a enablement-level null
-         // route to error page.
-         return null;
-       } else if (mainFeature.attributes['user-enabled']) { // feature is not toggled off and user-level is enabled
-         return {
-           'user-level': this.userLevel,
-           featuresPerLevel: {
-             internal,
-             experimental,
-             beta
-           }
-         } as FeatureFlagConfig;
-       } else { // feature is not toggled off but user-level is disabled, forward to opt-in page
-         return {
-           showBanner: this.getBannerColor(mainFeature.attributes['enablement-level'])
-         };
-       }
-     }
-   }
+
+  buildFeaturePerLevelView(features: Feature[], userLevel: string): FeatureFlagConfig {
+    let internal: Feature[] = [];
+    let experimental: Feature[] = [];
+    let beta: Feature[] = [];
+    let mainFeature: Feature;
+    for (let feature of features) {
+      if (feature.id.indexOf('.') === -1) {
+        mainFeature = feature;
+      }
+      feature.attributes.name = feature.id.replace('.', ' ');
+      switch (feature.attributes['enablement-level']) {
+        case 'beta': {
+          if (feature.attributes['enabled'] && feature.attributes['user-enabled']) {
+            beta.push(feature);
+          }
+          break;
+        }
+        case 'experimental': {
+          if (feature.attributes['enabled'] && feature.attributes['user-enabled']) {
+            experimental.push(feature);
+          }
+          break;
+        }
+        case 'internal': {
+          if (feature.attributes['enabled'] && feature.attributes['user-enabled']) {
+            internal.push(feature);
+          }
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    }
+    // this.logger.log('>> Feature = ' + featureName + ' enabled = ' + mainFeature.attributes['enabled']);
+    // if no feature at page menu level, the page has only component featuresmergeMa
+    if (!mainFeature) {
+      return {
+        'user-level': this.userLevel,
+        featuresPerLevel: {
+          internal,
+          experimental,
+          beta
+        }
+      } as FeatureFlagConfig;
+    } else if (!mainFeature.attributes['enabled']) { // PM has disabled the feature for all users
+      return null;
+    } else {
+      let enablementLevel = this.getBannerColor(mainFeature.attributes['enablement-level']);
+      if (enablementLevel === 'notApplicable') {
+        // for non-internal user trying to see internal feature toggles-service return a enablement-level null
+        // route to error page.
+        return null;
+      } else if (mainFeature.attributes['user-enabled']) { // feature is not toggled off and user-level is enabled
+        return {
+          'user-level': this.userLevel,
+          featuresPerLevel: {
+            internal,
+            experimental,
+            beta
+          }
+        } as FeatureFlagConfig;
+      } else { // feature is not toggled off but user-level is disabled, forward to opt-in page
+        return {
+          showBanner: this.getBannerColor(mainFeature.attributes['enablement-level'])
+        };
+      }
+    }
+  }
+
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<FeatureFlagConfig> {
     let featureName = route.data['featureName']; // + '.*';
     if (this.userService.currentLoggedInUser && this.userService.currentLoggedInUser.attributes) {
       this.userLevel = (this.userService.currentLoggedInUser.attributes as any).featureLevel;
     }
-    return this.toggleService.getFeaturesPerPage(featureName).map((features: Feature[]) => {
-       let config = this.buildFeaturePerLevelView(features, this.userLevel);
-       if (config == null) {
-         this.router.navigate(['/_error']);
-       } else if (!config.featuresPerLevel) {
-         this.router.navigate(['/_featureflag'], {queryParams: {
-             showBanner: config.showBanner
-           } });
-         return null;
-       }
-       return config;
-    }).catch (err => {
+    return this.toggleService.getFeaturesPerPage(featureName)
+      .map((features: Feature[]) => {
+        let config = this.buildFeaturePerLevelView(features, this.userLevel);
+        if (config == null) {
+          this.router.navigate(['/_error']);
+        } else if (!config.featuresPerLevel) {
+          this.router.navigate(['/_featureflag'], { queryParams: { showBanner: config.showBanner } });
+          return null;
+        }
+        return config;
+      })
+      .catch(err => {
         return Observable.of({
           showBanner: FeatureLevel.systemError
         } as FeatureFlagConfig);


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/4116
Fixes https://github.com/fabric8-services/fabric8-auth/issues/570

- `ngx-feature-flag` library was extracted out of `fabric8-ui` so that external libraries such as `fabric8-planner` would be able to use feature flags.
- But there is still one piece of code `FeatureFlagResolver` inside `fabric8-ui` which needs to move to `ngx-feature-flag` so that the other libraries do not need to write it all over again.